### PR TITLE
Add ability to set display logic on each component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 All notable changes to `spotlight` will be documented in this file.
 
+## Unreleased
+- Add `shouldBeShown` method to `SpotlightCommand` for any custom logic needed for determining whether a command should be shown in the Spotlight component.
+
 ## 0.1.6
 - Add `SpotlightCommandDependency` type support. Defaults to `SpotlightCommandDependency::SEARCH`
 - *Important* The dependency order was incorrect, you need to change your dependency order after updating if you have more than one dependency.
-
 
 ## 0.1.5
 - Add option to toggle Spotlight via browser events. `$this->dispatchBrowserEvent('toggle-spotlight');`

--- a/src/Spotlight.php
+++ b/src/Spotlight.php
@@ -82,14 +82,16 @@ class Spotlight extends Component
     public function render(): View | Factory
     {
         return view('livewire-ui-spotlight::spotlight', [
-            'commands' => collect(self::$commands)->map(function (SpotlightCommand $command) {
-                return [
-                    'id' => $command->getId(),
-                    'name' => $command->getName(),
-                    'description' => $command->getDescription(),
-                    'dependencies' => $command->dependencies()?->toArray() ?? [],
-                ];
-            }),
+            'commands' => collect(self::$commands)
+                ->filter(fn (SpotlightCommand $command) => $command->shouldBeShown())
+                ->map(function (SpotlightCommand $command) {
+                    return [
+                        'id' => $command->getId(),
+                        'name' => $command->getName(),
+                        'description' => $command->getDescription(),
+                        'dependencies' => $command->dependencies()?->toArray() ?? [],
+                    ];
+                }),
         ]);
     }
 }

--- a/src/SpotlightCommand.php
+++ b/src/SpotlightCommand.php
@@ -27,4 +27,9 @@ abstract class SpotlightCommand
     {
         return md5(static::class);
     }
+
+    public function shouldBeShown(): bool
+    {
+        return true;
+    }
 }

--- a/src/stubs/spotlight.stub
+++ b/src/stubs/spotlight.stub
@@ -61,4 +61,14 @@ class {{ class }} extends SpotlightCommand
     {
         $spotlight->redirectRoute('teams.users.create', $team);
     }
+
+    /**
+     * You can provide any custom logic you want to determine whether the
+     * command will shown in the Spotlight component. If you don't have any
+     * logic you can remove this method.
+     */
+    public function shouldBeShown(): bool
+    {
+        return true;
+    }
 }


### PR DESCRIPTION
This update allows for using a method on individual Spotlight Command components for any custom logic that should be used to determine whether the component should be shown in the Spotlight component. I went down this path primarily due to the fact that the authenticated user isn't available in the service providers.

I'm not in love with the method name. Originally I was using `shouldRegister`, but that's not really what's happening since the command component is registered, but is being filtered out before it's sent to the Livewire component. I settled on `shouldBeShown` since "shown" is the language that's used in some of the docblocks. If there's a better method name you can think of, I'm happy to change this.