### PR TITLE
Making the prompt translatable

### DIFF
--- a/resources/views/spotlight.blade.php
+++ b/resources/views/spotlight.blade.php
@@ -5,7 +5,7 @@
         <style>{!! file_get_contents($cssPath) !!}</style>
     @endisset
 
-    <div x-data="LivewireUISpotlight({ componentId: '{{ $this->id }}', placeholder: '{{ config('livewire-ui-spotlight.placeholder') }}', commands: {{ $commands }} })"
+    <div x-data="LivewireUISpotlight({ componentId: '{{ $this->id }}', placeholder: '{{ __(config('livewire-ui-spotlight.placeholder')) ?? config('livewire-ui-spotlight.placeholder') }}', commands: {{ $commands }} })"
          x-init="init()"
          x-show="isOpen"
          x-cloak


### PR DESCRIPTION
We want to use this component in a swedish environment and need to translate the phrase "What do you want to do?" in our language for our users.
This should not make any difference to not translated phrase.